### PR TITLE
Update postcss.config.js to adhere to correct configuration shape

### DIFF
--- a/source/postcss.config.js
+++ b/source/postcss.config.js
@@ -12,8 +12,6 @@
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
 
-const autoprefixer = require('autoprefixer')
-
 module.exports = {
-  plugins: [autoprefixer()],
+  plugins: ['autoprefixer'],
 }


### PR DESCRIPTION
## Rationale
`Next.js` requires postcss configuration to confirm to a specific configuration shape. Using an explicit require is no-longer supported as per guidance found in `Next.js` [documentation](https://nextjs.org/docs/messages/postcss-shape). Due to this configuration error deployments would fail.

## Changes

- replaced require statements found in `postcss.config.js` to string equivalent

**Before**
```
module.exports = {
  plugins: [autoprefixer()],
}
```

**After**
```
module.exports = {
  plugins: ['autoprefixer'],
}
```

Fixes #227